### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest
+pytest-cov

--- a/src/app.py
+++ b/src/app.py
@@ -108,3 +108,17 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.delete("/activities/{activity_name}/participants")
+def unregister_participant(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    activity = activities[activity_name]
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=404, detail="Participant not found in this activity")
+
+    activity["participants"] = [participant for participant in activity["participants"] if participant != email]
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports activities
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Wednesdays, 4:00 PM - 6:00 PM",
+        "max_participants": 18,
+        "participants": ["alex@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Basketball Club": {
+        "description": "Practice basketball skills and play friendly games",
+        "schedule": "Fridays, 5:00 PM - 7:00 PM",
+        "max_participants": 15,
+        "participants": ["mia@mergington.edu", "noah@mergington.edu"]
+    },
+    # Artistic activities
+    "Art Workshop": {
+        "description": "Explore painting, drawing, and other visual arts",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": ["ava@mergington.edu", "liam@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce school plays and performances",
+        "schedule": "Mondays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["charlotte@mergington.edu", "jack@mergington.edu"]
+    },
+    # Intellectual activities
+    "Math Olympiad": {
+        "description": "Prepare for math competitions and solve challenging problems",
+        "schedule": "Tuesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 10,
+        "participants": ["elijah@mergington.edu", "grace@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Conduct experiments and explore scientific topics",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 14,
+        "participants": ["benjamin@mergington.edu", "amelia@mergington.edu"]
     }
 }
 
@@ -61,6 +100,10 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+
+    # Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
 
     # Add student
     activity["participants"].append(email)

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -12,19 +12,48 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
         const activityCard = document.createElement("div");
         activityCard.className = "activity-card";
 
-        const spotsLeft = details.max_participants - details.participants.length;
+        const participants = Array.isArray(details.participants) ? details.participants : [];
+        const spotsLeft = details.max_participants - participants.length;
+        const participantItems = participants.length
+          ? participants
+              .map(
+                (participant) => `
+                <li class="participant-item">
+                  <span class="participant-email">${participant}</span>
+                  <button
+                    type="button"
+                    class="participant-remove-btn"
+                    data-activity="${encodeURIComponent(name)}"
+                    data-email="${encodeURIComponent(participant)}"
+                    aria-label="Unregister ${participant}"
+                    title="Unregister participant"
+                  >x</button>
+                </li>
+              `
+              )
+              .join("")
+          : '<li class="participants-empty">No students signed up yet.</li>';
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
-          <p><strong>Schedule:</strong> ${details.schedule}</p>
-          <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="activity-meta">
+            <p><strong>Schedule:</strong> ${details.schedule}</p>
+            <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          </div>
+          <div class="participants-section">
+            <p class="participants-heading">Participants (${participants.length})</p>
+            <ul class="participants-list">
+              ${participantItems}
+            </ul>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -62,6 +91,7 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        await fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";
@@ -78,6 +108,66 @@ document.addEventListener("DOMContentLoaded", () => {
       messageDiv.className = "error";
       messageDiv.classList.remove("hidden");
       console.error("Error signing up:", error);
+    }
+  });
+
+  activitiesList.addEventListener("click", async (event) => {
+    const removeButton = event.target.closest(".participant-remove-btn");
+    if (!removeButton) {
+      return;
+    }
+
+    const encodedActivity = removeButton.dataset.activity;
+    const encodedEmail = removeButton.dataset.email;
+    if (!encodedActivity || !encodedEmail) {
+      return;
+    }
+
+    const activityName = decodeURIComponent(encodedActivity);
+    const participantEmail = decodeURIComponent(encodedEmail);
+    const shouldUnregister = window.confirm(
+      `Are you sure you want to unregister ${participantEmail} from ${activityName}?`
+    );
+    if (!shouldUnregister) {
+      return;
+    }
+
+    removeButton.disabled = true;
+    let removedSuccessfully = false;
+
+    try {
+      const response = await fetch(
+        `/activities/${encodedActivity}/participants?email=${encodedEmail}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const result = await response.json();
+
+      if (response.ok) {
+        messageDiv.textContent = result.message;
+        messageDiv.className = "success";
+        removedSuccessfully = true;
+        await fetchActivities();
+      } else {
+        messageDiv.textContent = result.detail || "An error occurred";
+        messageDiv.className = "error";
+      }
+    } catch (error) {
+      messageDiv.textContent = "Failed to unregister participant. Please try again.";
+      messageDiv.className = "error";
+      console.error("Error unregistering participant:", error);
+    } finally {
+      if (!removedSuccessfully) {
+        removeButton.disabled = false;
+      }
+
+      messageDiv.classList.remove("hidden");
+
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 5000);
     }
   });
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -59,19 +59,108 @@ section h3 {
 
 .activity-card {
   margin-bottom: 15px;
-  padding: 15px;
-  border: 1px solid #ddd;
-  border-radius: 5px;
-  background-color: #f9f9f9;
+  padding: 16px;
+  border: 1px solid #d4ddff;
+  border-radius: 12px;
+  background: linear-gradient(150deg, #ffffff 0%, #f5f8ff 100%);
+  box-shadow: 0 8px 20px rgba(26, 35, 126, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.activity-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(26, 35, 126, 0.14);
 }
 
 .activity-card h4 {
   margin-bottom: 10px;
-  color: #0066cc;
+  color: #0b3f91;
 }
 
 .activity-card p {
   margin-bottom: 8px;
+}
+
+.activity-meta {
+  margin-top: 6px;
+}
+
+.participants-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed #c8d5ff;
+}
+
+.participants-heading {
+  margin: 0 0 8px;
+  font-weight: 700;
+  color: #1a237e;
+}
+
+.participants-list {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.participants-list li {
+  margin-bottom: 6px;
+  color: #334155;
+}
+
+.participants-list li::marker {
+  color: #3949ab;
+}
+
+.participant-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  background-color: #eef2ff;
+}
+
+.participant-email {
+  overflow-wrap: anywhere;
+}
+
+.participant-remove-btn {
+  width: 26px;
+  height: 26px;
+  border: 1px solid #f2b8b5;
+  border-radius: 50%;
+  background-color: #fff1f2;
+  color: #b42318;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, transform 0.15s ease;
+}
+
+.participant-remove-btn:hover {
+  background-color: #ffe4e6;
+  transform: scale(1.05);
+}
+
+.participant-remove-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.participants-empty {
+  list-style: none;
+  margin-left: 0;
+  color: #64748b;
+  font-style: italic;
+  background-color: #f8fafc;
+  padding: 6px 10px;
+  border-radius: 8px;
 }
 
 .form-group {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+from copy import deepcopy
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities_state():
+    original_state = deepcopy(activities)
+    yield
+    activities.clear()
+    activities.update(original_state)
+
+
+@pytest.fixture
+def activity_name():
+    return "Chess Club"
+
+
+@pytest.fixture
+def encoded_activity_name(activity_name):
+    return quote(activity_name, safe="")
+
+
+@pytest.fixture
+def existing_participant_email(activity_name):
+    return activities[activity_name]["participants"][0]

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,17 @@
+def test_get_activities_returns_expected_structure(client):
+    response = client.get("/activities")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert isinstance(payload, dict)
+    assert len(payload) > 0
+    assert "Chess Club" in payload
+
+    required_fields = {"description", "schedule", "max_participants", "participants"}
+    for details in payload.values():
+        assert required_fields.issubset(details.keys())
+        assert isinstance(details["description"], str)
+        assert isinstance(details["schedule"], str)
+        assert isinstance(details["max_participants"], int)
+        assert isinstance(details["participants"], list)

--- a/tests/test_signup.py
+++ b/tests/test_signup.py
@@ -1,0 +1,43 @@
+from urllib.parse import quote
+
+
+def test_signup_adds_new_participant(client, activity_name, encoded_activity_name):
+    email = "new.student@mergington.edu"
+
+    response = client.post(
+        f"/activities/{encoded_activity_name}/signup",
+        params={"email": email},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"message": f"Signed up {email} for {activity_name}"}
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+    assert email in participants
+
+
+def test_signup_rejects_duplicate_email(
+    client, activity_name, encoded_activity_name, existing_participant_email
+):
+    response = client.post(
+        f"/activities/{encoded_activity_name}/signup",
+        params={"email": existing_participant_email},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Student already signed up for this activity"
+    }
+
+
+def test_signup_returns_404_for_unknown_activity(client):
+    unknown_activity = quote("Unknown Activity", safe="")
+
+    response = client.post(
+        f"/activities/{unknown_activity}/signup",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}

--- a/tests/test_unregister.py
+++ b/tests/test_unregister.py
@@ -1,0 +1,43 @@
+from urllib.parse import quote
+
+
+def test_unregister_removes_existing_participant(
+    client, activity_name, encoded_activity_name, existing_participant_email
+):
+    response = client.delete(
+        f"/activities/{encoded_activity_name}/participants",
+        params={"email": existing_participant_email},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "message": f"Unregistered {existing_participant_email} from {activity_name}"
+    }
+
+    activities_response = client.get("/activities")
+    participants = activities_response.json()[activity_name]["participants"]
+    assert existing_participant_email not in participants
+
+
+def test_unregister_returns_404_for_missing_participant(client, encoded_activity_name):
+    response = client.delete(
+        f"/activities/{encoded_activity_name}/participants",
+        params={"email": "missing.student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "detail": "Participant not found in this activity"
+    }
+
+
+def test_unregister_returns_404_for_unknown_activity(client):
+    unknown_activity = quote("Unknown Activity", safe="")
+
+    response = client.delete(
+        f"/activities/{unknown_activity}/participants",
+        params={"email": "student@mergington.edu"},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Activity not found"}


### PR DESCRIPTION
This pull request introduces major improvements to the school activities management system, including new activity options, enhanced participant management (both signup and removal), a more interactive frontend, and comprehensive test coverage. These changes make the application more robust, user-friendly, and maintainable.

**Backend enhancements:**

* Added new activities across sports, artistic, and intellectual categories to the `activities` data structure in `src/app.py`, expanding options for students.
* Implemented participant removal functionality with a new `unregister_participant` endpoint, allowing students to be unregistered from activities and handling error cases for missing activities or participants.
* Improved signup validation by preventing duplicate participant registrations in the `signup_for_activity` function.

**Frontend improvements:**

* Updated the activities list UI in `src/static/app.js` to display participants for each activity, including a "remove" button for each participant, and handled empty states.
* Added interactive participant removal: users can unregister participants directly from the UI, with confirmation dialogs and feedback messages, and the list updates automatically. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R114-R173) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R94)
* Enhanced activity card styling and participant list appearance for improved readability and usability in `src/static/styles.css`.

**Testing improvements:**

* Added fixtures in `tests/conftest.py` to ensure test isolation and provide reusable test data for activities and participants.
* Introduced new tests for activity retrieval, signup (including error cases), and participant removal (including error cases) in `tests/test_activities.py`, `tests/test_signup.py`, and `tests/test_unregister.py`. [[1]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R17) [[2]](diffhunk://#diff-61ec098b3ee112a73dd8fad6565ff42d7189664d993b15b6e07d6ae5c718501eR1-R43) [[3]](diffhunk://#diff-21ccd8203cab33acf5126429131ad0a82f90f5710a8dd086d8974da3fb420462R1-R43)